### PR TITLE
Publish forked documentation website

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,12 +6,13 @@
 
 name: build
 
-on: 
-  workflow_dispatch: 
+on:
+  workflow_dispatch:
   workflow_call:
   push:
     branches:
       - main
+      - master
       - release/**
 
 env:
@@ -79,7 +80,7 @@ jobs:
         with:
           name: metadata.json
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
-  
+
   build-other:
     needs:
       - set-product-version

--- a/.github/workflows/doc-ci-cd.yml
+++ b/.github/workflows/doc-ci-cd.yml
@@ -1,0 +1,62 @@
+# Copyright (c) Jiaqi Liu
+name: Documentation CI/CD
+
+'on':
+  pull_request:
+  push:
+    branches:
+      - master
+jobs:
+  documentation-ci-cd:
+    name: Test & Release Documentation
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18  # must be 18 or above to avoid "Cannot read properties of undefined (reading 'version')"
+      - name: Test documentation build
+        run: npm run build
+      - name: Bundle up a GitHub Pages Deployable
+        if: github.ref == 'refs/heads/master'
+        run: |
+          mkdir hashicorp-packer-docs
+          cp -r website-preview/.next/server/pages/* hashicorp-packer-docs
+          
+          mkdir hashicorp-packer-docs/_next
+          cp -r website-preview/.next/static hashicorp-packer-docs/_next/static
+          
+          # The next command is not allowed by shellcheck. https://www.linuxjournal.com/content/bash-extended-globbing
+          # IMMUTABLE_DEPLOY_ARTIFACT_ID=$(ls website-preview/.next/static/ | grep -Ev "chunks|images|css|media")
+          # So we replace it with "find" command below
+          # Reference:
+          #   https://stackoverflow.com/a/6745470
+          #   https://stackoverflow.com/a/13525005
+          #   https://superuser.com/a/1016521
+          #   https://stackoverflow.com/a/7715567
+          IMMUTABLE_DEPLOY_ARTIFACT_ID=$(
+            find website-preview/.next/static/ \
+                -not -name images \
+                -not -name chunks \
+                -not -name css \
+                -not -name media \
+                -mindepth 1 \
+                -maxdepth 1 \
+                -execdir echo {} ';'
+          )
+          mkdir -p hashicorp-packer-docs/_next/data/"${IMMUTABLE_DEPLOY_ARTIFACT_ID}"
+          cp -r website-preview/.next/server/pages/* hashicorp-packer-docs/_next/data/"${IMMUTABLE_DEPLOY_ARTIFACT_ID}"
+          
+          cd hashicorp-packer-docs/
+          touch .nojekyll
+      - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/master'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: website/hashicorp-packer-docs
+          user_name: QubitPi
+          user_email: jack20191124@proton.me

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'master'
       - release/**
   pull_request:
 

--- a/.github/workflows/go-validate.yml
+++ b/.github/workflows/go-validate.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'master'
       - release/**
   pull_request:
 
@@ -74,4 +75,7 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
-      - run: make generate-check
+      - run: |
+          cd ../ && mv hashicorp-packer packer && cd packer
+          make generate-check
+          cd ../ && mv packer hashicorp-packer && cd hashicorp-packer

--- a/.github/workflows/go-validate.yml
+++ b/.github/workflows/go-validate.yml
@@ -76,6 +76,11 @@ jobs:
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
       - run: |
+          # Temporarily rename repo back to upstream name during make "generate-check" command run because
+          # the command requires the repo name to be "packer"
           cd ../ && mv hashicorp-packer packer && cd packer
+          
           make generate-check
+          
+          # Rename back because GitHub Action post processing requires the original checked-out repo name
           cd ../ && mv packer hashicorp-packer && cd hashicorp-packer

--- a/website/README.md
+++ b/website/README.md
@@ -1,3 +1,7 @@
+See [more details on how documentation is build][Forked HashiCorp Dev Portal]
+
+[Forked HashiCorp Dev Portal]: https://github.com/QubitPi/hashicorp-dev-portal
+
 # Packer Documentation Website
 
 This subdirectory contains the content for the [Packer Website](https://packer.io/).

--- a/website/scripts/website-build.sh
+++ b/website/scripts/website-build.sh
@@ -4,7 +4,7 @@
 ######################################################
 
 # Repo which we are cloning and executing npm run build:deploy-preview within
-REPO_TO_CLONE=dev-portal
+REPO_TO_CLONE=hashicorp-dev-portal
 # Set the subdirectory name for the base project
 PREVIEW_DIR=website-preview
 # The directory we want to clone the project into
@@ -31,7 +31,7 @@ fi
 
 # Clone the base project, if needed
 echo "⏳ Cloning the $REPO_TO_CLONE repo, this might take a while..."
-git clone --depth=1 "https://github.com/hashicorp/$REPO_TO_CLONE.git" "$CLONE_DIR"
+git clone --depth=1 "https://github.com/QubitPi/$REPO_TO_CLONE.git" "$CLONE_DIR"
 
 if [ "$from_cache" = true ]; then
   echo "Setting up $PREVIEW_DIR"
@@ -49,4 +49,5 @@ REPO=$PRODUCT \
 HASHI_ENV=project-preview \
 LOCAL_CONTENT_DIR=$LOCAL_CONTENT_DIR \
 CURRENT_GIT_BRANCH=$CURRENT_GIT_BRANCH \
+PRODUCT_DOC_BASE_PATH=/hashicorp-packer \
 npm run build:deploy-preview

--- a/website/scripts/website-start.sh
+++ b/website/scripts/website-start.sh
@@ -4,7 +4,7 @@
 ######################################################
 
 # Repo which we are cloning and executing npm run build:deploy-preview within
-REPO_TO_CLONE=dev-portal
+REPO_TO_CLONE=hashicorp-dev-portal
 # Set the subdirectory name for the dev-portal app
 PREVIEW_DIR=website-preview
 # The product for which we are building the deploy preview
@@ -24,7 +24,7 @@ should_pull=true
 # Clone the dev-portal project, if needed
 if [ ! -d "$PREVIEW_DIR" ]; then
     echo "⏳ Cloning the $REPO_TO_CLONE repo, this might take a while..."
-    git clone --depth=1 https://github.com/hashicorp/$REPO_TO_CLONE.git "$PREVIEW_DIR"
+    git clone --depth=1 https://github.com/QubitPi/$REPO_TO_CLONE.git "$PREVIEW_DIR"
     should_pull=false
 fi
 
@@ -41,4 +41,5 @@ PREVIEW_FROM_REPO=$PRODUCT \
 LOCAL_CONTENT_DIR=$LOCAL_CONTENT_DIR \
 CURRENT_GIT_BRANCH=$CURRENT_GIT_BRANCH \
 PREVIEW_MODE=$PREVIEW_MODE \
+PRODUCT_DOC_BASE_PATH=/hashicorp-packer \
 npm run start:local-preview


### PR DESCRIPTION
- Add documentation CI/CD

  - Any pull request triggers the documentation test build
  - Any commits to `master` branch triggers the same test build and then automatically deploys the documentation to GitHub Pags

- Temporarily rename repo back to upstream name during `make generate-check` command run because the command requires the repo name to be "packer"
- All GitHub actions that targets upstream `main` also triggers on `master`, which is the default branch of this fork