### PR TITLE
Fix docker build error during release process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,6 +225,7 @@ jobs:
 
   build-docker:
     name: Docker light ${{ matrix.arch }} build
+    if: github.repository != 'QubitPi/hashicorp-packer'
     needs:
       - set-product-version
       - build-linux


### PR DESCRIPTION
- Fix [release error](https://github.com/QubitPi/hashicorp-packer/actions/runs/4905830924/jobs/8760014812) by dis-enabling [irrelevant actions](https://github.com/hashicorp/actions-docker-build)